### PR TITLE
Fix timestamp parsing in python 3.10+

### DIFF
--- a/plistutils/utils.py
+++ b/plistutils/utils.py
@@ -74,7 +74,9 @@ def parse_timestamp(qword, resolution, epoch_shift, mode=decimal.ROUND_HALF_EVEN
     total_microseconds = (decimal.Decimal(shifted * datetime_resolution) / decimal.Decimal(resolution)).quantize(1, mode)
 
     # convert to datetime
-    return datetime.utcfromtimestamp(total_microseconds // datetime_resolution).replace(microsecond=total_microseconds % datetime_resolution)
+    timestamp = int(total_microseconds // datetime_resolution)
+    microsecond = int(total_microseconds % datetime_resolution)
+    return datetime.utcfromtimestamp(timestamp).replace(microsecond=microsecond)
 
 
 def case_insensitive_dict_get(d, key, default=None):


### PR DESCRIPTION
Python 3.9 gives a deprecation warning:
```
$ python -c 'import datetime; import decimal; print(datetime.datetime.utcfromtimestamp(decimal.Decimal(3)))'
<string>:1: DeprecationWarning: an integer is required (got type decimal.Decimal).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
1970-01-01 00:00:03
```

And in python 3.10, decimal timestamp support was removed:
```
$ python -c 'import datetime; import decimal; print(datetime.datetime.utcfromtimestamp(decimal.Decimal(3)))'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: 'decimal.Decimal' object cannot be interpreted as an integer
```